### PR TITLE
Nicer help message for --log-level

### DIFF
--- a/argparse_logging.py
+++ b/argparse_logging.py
@@ -12,6 +12,9 @@ class LogLevel(Enum):
     CRITICAL = logging.CRITICAL
     FATAL = logging.FATAL
 
+    def __str__(self):
+        return self.name
+
 
 class LoggingAction(Action):
     """Abstraction for the different log parsers."""
@@ -53,7 +56,7 @@ def add_log_level_argument(
         type=lambda x: getattr(LogLevel, x),
         default=LogLevel.INFO,
         action=LogLevelAction,
-        help=f"Logging level ({[l.name for l in LogLevel]}).",
+        help=f"Logging level.",
     )
 
 


### PR DESCRIPTION
argparse automatically adds a list of choices to the help, which makes the current help message a bit ugly:

```
  --log-level {LogLevel.DEBUG,LogLevel.INFO,LogLevel.WARNING,LogLevel.ERROR,LogLevel.CRITICAL}
                        Logging level (['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']).
```

This patch removes the manually generated list of choices at the end and makes argparse's list look nicer (without "LogLevel." prefix)